### PR TITLE
Fix: "EISDIR: illegal operation on a directory" on export

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -42,10 +42,9 @@ export default {
     config: {
       purge: {
         content: [
-          'assets',
-          'components',
-          'layouts',
-          'pages'
+          'components/**/*.vue',
+          'layouts/**/*.vue',
+          'pages/**/*.vue'
         ]
       },
       theme: {


### PR DESCRIPTION
### Problem
Various `EISDIR` errors when trying to run `npm run export`

### Fix
Turned out to be an issue with the way the purge folders were defined. Making them more specific fixed the issue.